### PR TITLE
B2: Added project requirements

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -5,7 +5,18 @@
 # accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt
 
+import config : requires ;
 import testing ;
+
+project
+    : requirements
+        [ requires
+            cxx14_constexpr
+            cxx14_decltype_auto
+            cxx14_generic_lambdas
+            cxx14_return_type_deduction
+        ]
+    ;
 
 run deref.cpp ;
 run value.cpp ;


### PR DESCRIPTION
B2 skips tests if the compiler does not support asked language features. This will effectively reduce load on workers with unsupported compilers and make boost regression matrix clearer.