### PR TITLE
Fixed an bug in placeholder_transform_t::operator() which used a non-…

### DIFF
--- a/include/boost/yap/detail/transform.hpp
+++ b/include/boost/yap/detail/transform.hpp
@@ -85,9 +85,8 @@ namespace boost { namespace yap { namespace detail {
                 I <= decltype(hana::size(std::declval<tuple_t>()))::value,
                 "Out of range placeholder index,");
             using nth_type = nth_element<I - 1, PlaceholderArgs...>;
-            return as_expr<minimal_expr>(
-                rvalue_mover<!std::is_lvalue_reference<nth_type>::value>::value(
-                    placeholder_args_[hana::llong<I - 1>{}]));
+            return rvalue_mover<!std::is_lvalue_reference<nth_type>::value>{}(
+                placeholder_args_[hana::llong<I - 1>{}]);
         }
 
         tuple_t placeholder_args_;

--- a/include/boost/yap/detail/transform.hpp
+++ b/include/boost/yap/detail/transform.hpp
@@ -85,8 +85,9 @@ namespace boost { namespace yap { namespace detail {
                 I <= decltype(hana::size(std::declval<tuple_t>()))::value,
                 "Out of range placeholder index,");
             using nth_type = nth_element<I - 1, PlaceholderArgs...>;
-            return rvalue_mover<!std::is_lvalue_reference<nth_type>::value>{}(
-                placeholder_args_[hana::llong<I - 1>{}]);
+            return as_expr<minimal_expr>(
+                rvalue_mover<!std::is_lvalue_reference<nth_type>::value>{}(
+                    placeholder_args_[hana::llong<I - 1>{}]));
         }
 
         tuple_t placeholder_args_;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,6 +44,7 @@ add_test_executable(comma)
 add_test_executable(if_else)
 add_test_executable(expression_function)
 add_test_executable(transform)
+add_test_executable(supplied_transforms)
 
 add_executable(
     compile_tests

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -38,6 +38,7 @@ run comma.cpp ;
 run if_else.cpp ;
 run expression_function.cpp ;
 run transform.cpp ;
+run supplied_transforms.cpp ;
 
 compile compile_is_expr.cpp ;
 compile compile_const_term.cpp ;

--- a/test/print.cpp
+++ b/test/print.cpp
@@ -1591,5 +1591,15 @@ int test_main(int, char * [])
         }
     }
 
+    {
+        using namespace yap::literals;
+        std::ostringstream oss;
+        yap::print(oss, replace_placeholders(1_p + 2_p,7,8));
+        BOOST_CHECK(fix_tti(oss.str()) == R"(expr<+>
+    term<int>[=7]
+    term<int>[=8]
+)");
+    }
+
     return 0;
 }

--- a/test/supplied_transforms.cpp
+++ b/test/supplied_transforms.cpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2019 Paul Keir
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+#include <boost/yap/yap.hpp>
+
+#include <boost/test/minimal.hpp>
+
+namespace yap = boost::yap;
+
+int test_main(int, char * [])
+{
+    // Test replacements(), which returns a transform object
+    {
+        using namespace boost::yap::literals;
+
+        auto expr_in  = 1_p * 2_p;
+        auto xform    = yap::replacements(6,9);
+        auto expr_out = yap::transform(expr_in,xform);
+        auto result   = yap::evaluate(expr_out);
+        BOOST_CHECK(result == 54);
+    }
+
+    // Test evaluation(), which returns a transform object
+    {
+        using namespace boost::yap::literals;
+
+        auto expr_in  = 1_p * 2_p;
+        auto xform    = yap::evaluation(7,10);
+        auto result   = yap::transform(expr_in,xform);
+        BOOST_CHECK(result == 70);
+    }
+
+    // Test replace_placeholders(), which returns an expression 
+    {
+        using namespace boost::yap::literals;
+
+        auto expr_in  = 1_p * 2_p;
+        auto expr_out = yap::replace_placeholders(expr_in,8,11);
+        auto result   = yap::evaluate(expr_out);
+        BOOST_CHECK(result == 88);
+    }
+
+    return 0;
+}
+


### PR DESCRIPTION
…existent value member of rvalue_mover. This allows replacements() and replace_placeholders() to be used. Also added a test file which checks these two, as well as evaluation().